### PR TITLE
Update landing page to use Sized box and Components

### DIFF
--- a/lib/landing.dart
+++ b/lib/landing.dart
@@ -38,7 +38,7 @@ class Landing extends StatelessWidget {
           ),
         ),
       ),
-    ); // 11.9.20: working w/ scaffold / body, SafeWidget introduced
+    ); 
   }
 }
 

--- a/lib/landing.dart
+++ b/lib/landing.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 class Landing extends StatelessWidget {
+  static const spacing = 30.0;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -14,82 +16,42 @@ class Landing extends StatelessWidget {
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       body: SafeArea(
         child: Padding(
-          padding: const EdgeInsets.all(30.0),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            // super dope, could also be .center to center up //
-            crossAxisAlignment: CrossAxisAlignment.stretch, // super dope //
+          padding: const EdgeInsets.all(spacing),
+          child: ListView(
             children: <Widget>[
-              // Text(                // come back to with group, 11.11.20
-              //   'rubric', // not happy with this, wanting to load SvgPicture widget
-              //   style: TextStyle(
-              //     color: Colors.white,
-              //     fontSize: 20,
-              //   ),
-              // ),
-              SizedBox(height: 30),
-              Container(
-                height: 230,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(10),
-                  color: const Color(0xff8743D3),
-                ),
-              ),
-              SizedBox(height: 30),
+              SizedBox(height: spacing),
+              RubricCard(),
+              SizedBox(height: spacing),
               Row(
                 children: <Widget>[
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.only(right: 15.0),
-                      child: Container(
-                        height: 230,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: const Color(0xff8743D3),
-                        ),
-                        child: FittedBox(
-                          fit: BoxFit.contain,
-                        ),
-                      ),
-                    ),
-                  ),
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.only(left: 15.0),
-                      child: Container(
-                        height: 230,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(10),
-                          color: const Color(0xff8743D3),
-                        ),
-                        child: FittedBox(
-                          fit: BoxFit.contain,
-                        ),
-                      ),
-                    ),
-                  ),
+                  Expanded(child: RubricCard()),
+                  SizedBox(width: spacing),
+                  Expanded(child: RubricCard()),
                 ],
               ),
-              // Container(
-
-              //   height: 230,
-              //   decoration: BoxDecoration(
-              //     borderRadius: BorderRadius.circular(10),
-              //     color: const Color(0xff8743D3),
-              //   ),
-              // ),
-              SizedBox(height: 30),
-              Container(
-                height: 230,
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(10),
-                  color: const Color(0xff8743D3),
-                ),
-              ),
+              SizedBox(height: spacing),
+              RubricCard(),
             ],
           ),
         ),
       ),
     ); // 11.9.20: working w/ scaffold / body, SafeWidget introduced
+  }
+}
+
+class RubricCard extends StatelessWidget {
+  const RubricCard({
+    Key key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 230,
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(10),
+        color: const Color(0xff8743D3),
+      ),
+    );
   }
 }

--- a/lib/landing.dart
+++ b/lib/landing.dart
@@ -16,6 +16,9 @@ class Landing extends StatelessWidget {
       floatingActionButtonLocation: FloatingActionButtonLocation.centerDocked,
       body: SafeArea(
         child: Padding(
+          //mainAxisAlignment: MainAxisAlignment.start,
+          // super dope, could also be .center to center up
+          // crossAxisAlignment: CrossAxisAlignment.stretch,
           padding: const EdgeInsets.all(spacing),
           child: ListView(
             children: <Widget>[


### PR DESCRIPTION
Just doing a little clean up. Let me know if this makes sense.

## Proposed Changes
- Rafactor the `Container` with `height` and `decoration` properties into its own `Component` called `RubricCard` (at bottom of page)
- Remove left and right `Padding` in favor of a `SizedBox` widget
- Create a class level `const` for the size of your padding/margins
- Remove `child` named argument of `Container` since it wasn't needed


## Before & After
_Nothing changes in the UI, only code refactor._
| Before | After |
|--|--|
|![Simulator Screen Shot - iPhone 12 Pro Max - 2020-11-11 at 09 23 53](https://user-images.githubusercontent.com/27933222/98837086-bd084300-23ff-11eb-8eb0-46174bf63e6d.png)|![Simulator Screen Shot - iPhone 12 Pro Max - 2020-11-11 at 09 23 31](https://user-images.githubusercontent.com/27933222/98837094-c0033380-23ff-11eb-9ce4-20c1beca1c94.png)|